### PR TITLE
Added support for Cyanide & Happiness comic, and changed url usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,9 @@ Check [node-comics-feed](https://github.com/leesei/node-comics-feed) for support
 
 ## Tested on
 
-http://localhost:5000/embed/http%3A%2F%2Ffeed.dilbert.com%2Fdilbert%2Fdaily_strip  
-http://localhost:5000/embed/http%3A%2F%2Ffeeds.feedburner.com%2Fuclick%2Fdilbert-classics
+- http://localhost:5000/embed/http%3A%2F%2Ffeed.dilbert.com%2Fdilbert%2Fdaily_strip  
+- http://localhost:5000/embed/http%3A%2F%2Ffeeds.feedburner.com%2Fuclick%2Fdilbert-classics
+- http://localhost:5000/embed/http%3A%2F%2Ffeeds.feedburner.com%2FExplosm
 
 To local host the application:
 

--- a/index.js
+++ b/index.js
@@ -19,7 +19,13 @@ app.get('/', function(req, res) {
 });
 
 app.get('/embed/:url', function(req, res) {
-  var feedUrl = decodeURIComponent(req.params.url);
+  var feedUrl = "";
+  if(req.params.url === "CH") {
+    // shortcut for Cyanide & Happiness comic...
+    feedUrl = "http://feeds.feedburner.com/Explosm";
+  } else {
+    feedUrl = decodeURIComponent(req.params.url);
+  }
   console.log('Processing: ' + feedUrl);
 
   // only supports feed from HTTP server

--- a/index.js
+++ b/index.js
@@ -23,14 +23,8 @@ app.get('/', function(req, res) {
 // or without % encoding:
 // http://feed.dilbert.com/dilbert/daily_strip
 app.get(/^\/embed\/(.*)$/, function(req, res) {
-  paramurl = req.params[0];
-  var feedUrl = "";
-  if(paramurl === "CH") {
-    // shortcut for Cyanide & Happiness comic...
-    feedUrl = "http://feeds.feedburner.com/Explosm";
-  } else {
-    feedUrl = decodeURIComponent(paramurl);
-  }
+  var rawUrl = req.params[0];
+  var feedUrl = decodeURIComponent(rawUrl);
   console.log('Processing: ' + feedUrl);
 
   // only supports feed from HTTP server

--- a/index.js
+++ b/index.js
@@ -18,13 +18,18 @@ app.get('/', function(req, res) {
   res.send(index);
 });
 
-app.get('/embed/:url', function(req, res) {
+// The routing here is /embed/<ORIGINAL RSS URL> where the URL can be encoded e.g.
+// http%3A%2F%2Ffeed.dilbert.com%2Fdilbert%2Fdaily_strip
+// or without % encoding:
+// http://feed.dilbert.com/dilbert/daily_strip
+app.get(/^\/embed\/(.*)$/, function(req, res) {
+  paramurl = req.params[0];
   var feedUrl = "";
-  if(req.params.url === "CH") {
+  if(paramurl === "CH") {
     // shortcut for Cyanide & Happiness comic...
     feedUrl = "http://feeds.feedburner.com/Explosm";
   } else {
-    feedUrl = decodeURIComponent(req.params.url);
+    feedUrl = decodeURIComponent(paramurl);
   }
   console.log('Processing: ' + feedUrl);
 

--- a/index.js
+++ b/index.js
@@ -39,7 +39,7 @@ app.get('/embed/:url', function(req, res) {
     {
       url: feedUrl,
       verbose: true,
-      maxitems: 5
+      maxitems: 0
     },
     function (err, feedXml) {
       if (err) {

--- a/index.js
+++ b/index.js
@@ -32,7 +32,8 @@ app.get('/embed/:url', function(req, res) {
   comicsFeed.embedStrips(
     {
       url: feedUrl,
-      verbose: true
+      verbose: true,
+      maxitems: 5
     },
     function (err, feedXml) {
       if (err) {

--- a/index.js
+++ b/index.js
@@ -37,8 +37,7 @@ app.get(/^\/embed\/(.*)$/, function(req, res) {
   comicsFeed.embedStrips(
     {
       url: feedUrl,
-      verbose: true,
-      maxitems: 0
+      verbose: true
     },
     function (err, feedXml) {
       if (err) {

--- a/package.json
+++ b/package.json
@@ -10,10 +10,10 @@
   "main": "index.js",
   "repository": {
     "type": "git",
-    "url": "git://github.com/leesei/heroku-comics-feed.git"
+    "url": "git://github.com/eguendelman/heroku-comics-feed.git"
   },
   "bugs": {
-    "url": "https://github.com/leesei/heroku-comics-feed/issues"
+    "url": "https://github.com/eguendelman/heroku-comics-feed/issues"
   },
   "keywords": [
     "rss",
@@ -22,7 +22,7 @@
     "scrape"
   ],
   "dependencies": {
-    "comics-feed": "git+https://github.com/leesei/node-comics-feed.git",
+    "comics-feed": "git+https://github.com/eguendelman/node-comics-feed.git#eguendelman-cyanideandhappiness",
     "express": "~3.4.7"
   },
   "license": "MIT"


### PR DESCRIPTION
As part of my fork of node-comics-feed to support Cyanide & Happiness, I also changed this slightly.

The main technical change is that it now supports URLs of the form

/embed/URL

where URL doesn't necessarily have to be % encoded (i.e. can write http://feed.dilbert.com/dilbert/daily_strip instead of http%3A%2F%2Ffeed.dilbert.com%2Fdilbert%2Fdaily_strip).  I did this because for some reason when using % encoded URLs I was not able to properly subscribe to the RSS from Feedly...

Also you will see that I changed links in package.json to point to my version of the node-comics-feed project...  Please tell me if this is not the standard way to do things during fork/pull request.

Thanks
